### PR TITLE
fix: 修复直播文本渲染

### DIFF
--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -292,7 +292,7 @@ function renderText(item: BilibiliDynamicItem): string {
     result = `${author.name} 转发动态: ${dynamic.desc.text}\n${renderText(item.orig)}`
   } else if (item.type === 'DYNAMIC_TYPE_LIVE_RCMD') {
     const dynamic = item.modules.module_dynamic
-    const info: LivePlayInfo = JSON.parse(dynamic.major.live_rcmd.content)
+    const info: LivePlayInfo = JSON.parse(dynamic.major.live_rcmd.content).live_play_info
     result = `${author.name} 开始直播: ${info.title}`
     if (info.cover) result += `\n${segment.image(info.cover)}`
   } else {


### PR DESCRIPTION
推送直播动态时无法正确发送直播标题和封面：

```
Bryan不可思议 开始直播: undefined
https://t.bilibili.com/...
```

期望行为：

```
Bryan不可思议 开始直播: 直播标题
[直播封面]
https://t.bilibili.com/...
```
